### PR TITLE
Add params string[] option to CreateRequest.

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -8,6 +8,7 @@ is updated in preparation for publishing an updated NuGet package.
 Prefix the description of the change with `[major]`, `[minor]` or `[patch]` in accordance with [SemVer](http://semver.org).
 
 * [patch] Change the only ConfigureAwait(true) to ConfigureAwait(false).
+* [minor] Add `params string[]` option to `CreateRequest`.
 
 ## Released
 

--- a/src/Faithlife.WebRequests/Json/JsonWebServiceClientBase.cs
+++ b/src/Faithlife.WebRequests/Json/JsonWebServiceClientBase.cs
@@ -70,15 +70,15 @@ namespace Faithlife.WebRequests.Json
 		/// Creates a web request URI using the specified relative URI pattern and parameters.
 		/// </summary>
 		/// <param name="relativeUriPattern">The relative URI pattern.</param>
-		/// <param name="parameters">The URI parameters.</param>
+		/// <param name="uriParameters">The URI parameters.</param>
 		/// <returns>The web request URI.</returns>
 		/// <remarks>Each pair of parameters represents a key and a value. See UriUtility.FromPattern for acceptable parameter values.</remarks>
-		protected Uri GetRequestUri(string relativeUriPattern, params string[] parameters)
+		protected Uri GetRequestUri(string relativeUriPattern, params string[] uriParameters)
 		{
 			if (relativeUriPattern == null)
 				throw new ArgumentNullException("relativeUriPattern");
 
-			return DoGetRequestUri(relativeUriPattern, parameters);
+			return DoGetRequestUri(relativeUriPattern, uriParameters);
 		}
 
 		/// <summary>
@@ -120,12 +120,12 @@ namespace Faithlife.WebRequests.Json
 		/// </summary>
 		/// <typeparam name="TResponse">The type of the response.</typeparam>
 		/// <param name="relativeUriPattern">The relative URI pattern.</param>
-		/// <param name="parameters">The URI parameters.</param>
+		/// <param name="uriParameters">The URI parameters.</param>
 		/// <returns>The new AutoWebServiceRequest.</returns>
 		/// <remarks>Each pair of parameters represents a key and a value. See UriUtility.FromPattern for acceptable parameter values.</remarks>
-		protected AutoWebServiceRequest<TResponse> CreateRequest<TResponse>(string relativeUriPattern, params string[] parameters)
+		protected AutoWebServiceRequest<TResponse> CreateRequest<TResponse>(string relativeUriPattern, params string[] uriParameters)
 		{
-			return DoCreateRequest<TResponse>(GetRequestUri(relativeUriPattern, parameters));
+			return DoCreateRequest<TResponse>(GetRequestUri(relativeUriPattern, uriParameters));
 		}
 
 		/// <summary>
@@ -158,14 +158,14 @@ namespace Faithlife.WebRequests.Json
 			return uri;
 		}
 
-		private Uri DoGetRequestUri(string relativeUriPattern, params string[] parameters)
+		private Uri DoGetRequestUri(string relativeUriPattern, params string[] uriParameters)
 		{
 			string uriText = m_baseUri.AbsoluteUri;
 
 			if (!string.IsNullOrEmpty(relativeUriPattern))
 				uriText = uriText.TrimEnd('/') + "/" + relativeUriPattern.TrimStart('/');
 
-			Uri uri = parameters != null ? UriUtility.FromPattern(uriText, parameters) : new Uri(uriText);
+			Uri uri = uriParameters != null ? UriUtility.FromPattern(uriText, uriParameters) : new Uri(uriText);
 
 			OnGetRequestUri(ref uri);
 

--- a/src/Faithlife.WebRequests/Json/JsonWebServiceClientBase.cs
+++ b/src/Faithlife.WebRequests/Json/JsonWebServiceClientBase.cs
@@ -33,7 +33,7 @@ namespace Faithlife.WebRequests.Json
 		/// <returns>The web request URI.</returns>
 		protected Uri GetRequestUri()
 		{
-			return DoGetRequestUri(null, null);
+			return DoGetRequestUri(null);
 		}
 
 		/// <summary>
@@ -46,7 +46,7 @@ namespace Faithlife.WebRequests.Json
 			if (relativeUri == null)
 				throw new ArgumentNullException("relativeUri");
 
-			return DoGetRequestUri(relativeUri, null);
+			return DoGetRequestUri(relativeUri);
 		}
 
 		/// <summary>
@@ -64,6 +64,21 @@ namespace Faithlife.WebRequests.Json
 				throw new ArgumentNullException("uriParameters");
 
 			return DoGetRequestUri(relativeUriPattern, uriParameters);
+		}
+
+		/// <summary>
+		/// Creates a web request URI using the specified relative URI pattern and parameters.
+		/// </summary>
+		/// <param name="relativeUriPattern">The relative URI pattern.</param>
+		/// <param name="parameters">The URI parameters.</param>
+		/// <returns>The web request URI.</returns>
+		/// <remarks>Each pair of parameters represents a key and a value. See UriUtility.FromPattern for acceptable parameter values.</remarks>
+		protected Uri GetRequestUri(string relativeUriPattern, params string[] parameters)
+		{
+			if (relativeUriPattern == null)
+				throw new ArgumentNullException("relativeUriPattern");
+
+			return DoGetRequestUri(relativeUriPattern, parameters);
 		}
 
 		/// <summary>
@@ -101,6 +116,19 @@ namespace Faithlife.WebRequests.Json
 		}
 
 		/// <summary>
+		/// Creates a new AutoWebServiceRequest using the specified relative URI pattern and parameters.
+		/// </summary>
+		/// <typeparam name="TResponse">The type of the response.</typeparam>
+		/// <param name="relativeUriPattern">The relative URI pattern.</param>
+		/// <param name="parameters">The URI parameters.</param>
+		/// <returns>The new AutoWebServiceRequest.</returns>
+		/// <remarks>Each pair of parameters represents a key and a value. See UriUtility.FromPattern for acceptable parameter values.</remarks>
+		protected AutoWebServiceRequest<TResponse> CreateRequest<TResponse>(string relativeUriPattern, params string[] parameters)
+		{
+			return DoCreateRequest<TResponse>(GetRequestUri(relativeUriPattern, parameters));
+		}
+
+		/// <summary>
 		/// Called to modify the request URI before it is sent.
 		/// </summary>
 		/// <param name="uri">The request URI.</param>
@@ -124,6 +152,20 @@ namespace Faithlife.WebRequests.Json
 				uriText = uriText.TrimEnd('/') + "/" + relativeUriPattern.TrimStart('/');
 
 			Uri uri = uriParameters != null ? UriUtility.FromPattern(uriText, uriParameters) : new Uri(uriText);
+
+			OnGetRequestUri(ref uri);
+
+			return uri;
+		}
+
+		private Uri DoGetRequestUri(string relativeUriPattern, params string[] parameters)
+		{
+			string uriText = m_baseUri.AbsoluteUri;
+
+			if (!string.IsNullOrEmpty(relativeUriPattern))
+				uriText = uriText.TrimEnd('/') + "/" + relativeUriPattern.TrimStart('/');
+
+			Uri uri = parameters != null ? UriUtility.FromPattern(uriText, parameters) : new Uri(uriText);
 
 			OnGetRequestUri(ref uri);
 

--- a/src/Faithlife.WebRequests/Json/JsonWebServiceClientBase.cs
+++ b/src/Faithlife.WebRequests/Json/JsonWebServiceClientBase.cs
@@ -146,10 +146,7 @@ namespace Faithlife.WebRequests.Json
 
 		private Uri DoGetRequestUri(string relativeUriPattern, IEnumerable<KeyValuePair<string, object>> uriParameters)
 		{
-			string uriText = m_baseUri.AbsoluteUri;
-
-			if (!string.IsNullOrEmpty(relativeUriPattern))
-				uriText = uriText.TrimEnd('/') + "/" + relativeUriPattern.TrimStart('/');
+			string uriText = JoinUriWithRelativePattern(m_baseUri, relativeUriPattern);
 
 			Uri uri = uriParameters != null ? UriUtility.FromPattern(uriText, uriParameters) : new Uri(uriText);
 
@@ -160,16 +157,23 @@ namespace Faithlife.WebRequests.Json
 
 		private Uri DoGetRequestUri(string relativeUriPattern, params string[] uriParameters)
 		{
-			string uriText = m_baseUri.AbsoluteUri;
-
-			if (!string.IsNullOrEmpty(relativeUriPattern))
-				uriText = uriText.TrimEnd('/') + "/" + relativeUriPattern.TrimStart('/');
+			string uriText = JoinUriWithRelativePattern(m_baseUri, relativeUriPattern);
 
 			Uri uri = uriParameters != null ? UriUtility.FromPattern(uriText, uriParameters) : new Uri(uriText);
 
 			OnGetRequestUri(ref uri);
 
 			return uri;
+		}
+
+		private static string JoinUriWithRelativePattern(Uri baseUri, string relativeUriPattern)
+		{
+			string uriText = baseUri.AbsoluteUri;
+
+			if (!string.IsNullOrEmpty(relativeUriPattern))
+				uriText = uriText.TrimEnd('/') + "/" + relativeUriPattern.TrimStart('/');
+
+			return uriText;
 		}
 
 		private AutoWebServiceRequest<TResponse> DoCreateRequest<TResponse>(Uri uri)

--- a/tests/Faithlife.WebRequests.Tests/CreateRequestTests.cs
+++ b/tests/Faithlife.WebRequests.Tests/CreateRequestTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Faithlife.WebRequests.Json;
+using NUnit.Framework;
+
+namespace Faithlife.WebRequests.Tests
+{
+	[TestFixture]
+	public sealed class CreateRequestTests
+	{
+		[Test]
+		public void CreateRequestWithIEnumerableParameters()
+		{
+			var client = CreateMockClient();
+
+			var parameters = new Dictionary<string, object>();
+			parameters.Add("id", "1234");
+			parameters.Add("test", "1");
+
+			var request = client.CreateRequest<object>("tests/{id}", parameters.ToList());
+
+			Assert.AreEqual(request.RequestUri.AbsoluteUri, "https://testapi.faithlife.com/v1/tests/1234?test=1");
+		}
+
+		[Test]
+		public void CreateRequestWithStringParams()
+		{
+			var client = CreateMockClient();
+
+			var request = client.CreateRequest<object>("tests/{id}", "id", "1234", "test", "1");
+
+			Assert.AreEqual(request.RequestUri.AbsoluteUri, "https://testapi.faithlife.com/v1/tests/1234?test=1");
+		}
+
+		private MockWebServiceClient CreateMockClient()
+		{
+			return new MockWebServiceClient(s_baseUri, new JsonWebServiceClientSettings());
+		}
+
+		private static Uri s_baseUri = new Uri("https://testapi.faithlife.com/v1/");
+	}
+
+	sealed class MockWebServiceClient : JsonWebServiceClientBase
+	{
+		public MockWebServiceClient(Uri baseUri, JsonWebServiceClientSettings clientSettings)
+			: base(baseUri, clientSettings)
+		{
+		}
+
+		public new AutoWebServiceRequest<TResponse> CreateRequest<TResponse>(string relativeUriPattern, IEnumerable<KeyValuePair<string, object>> uriParameters)
+		{
+			return base.CreateRequest<TResponse>(relativeUriPattern, uriParameters);
+		}
+
+		public new AutoWebServiceRequest<TResponse> CreateRequest<TResponse>(string relativeUriPattern, params string[] parameters)
+		{
+			return base.CreateRequest<TResponse>(relativeUriPattern, parameters);
+		}
+	}
+}

--- a/tests/Faithlife.WebRequests.Tests/CreateRequestTests.cs
+++ b/tests/Faithlife.WebRequests.Tests/CreateRequestTests.cs
@@ -14,9 +14,10 @@ namespace Faithlife.WebRequests.Tests
 		{
 			var client = CreateMockClient();
 
-			var parameters = new Dictionary<string, object>();
-			parameters.Add("id", "1234");
-			parameters.Add("test", "1");
+			var parameters = new Dictionary<string, object> {
+				["id"] = "1234",
+				["test"] = "1",
+			};
 
 			var request = client.CreateRequest<object>("tests/{id}", parameters.ToList());
 


### PR DESCRIPTION
The `params string[] parameters` overload exists in [`UriUtility.FromFormat`](https://github.com/Faithlife/FaithlifeUtility/blob/7ba7b39454ce1b35c4666b4182b940b3e1db95e8/src/Faithlife.Utility/UriUtility.cs#L20), but was not surfaced in `Faithlife.WebRequests`.

Now that we [no longer](https://github.com/Faithlife/FaithlifeUtility/commit/04b7ccbe905ba2295b6d94e8510c6706bf8a8db3) have the `object` overload that uses reflection, there is not a way to have `CreateRequest` replace fields in a format string without creating an `IEnumerable<KeyValuePair<string, object>>`.