### PR TITLE
Add If-Match header support.

### DIFF
--- a/src/Faithlife.WebRequests/WebServiceRequestBase.cs
+++ b/src/Faithlife.WebRequests/WebServiceRequestBase.cs
@@ -61,6 +61,12 @@ namespace Faithlife.WebRequests
 		public HttpContent Content { get; set; }
 
 		/// <summary>
+		/// Gets or sets the If-Match header.
+		/// </summary>
+		/// <value>The If-Match ETag.</value>
+		public string IfMatch { get; set; }
+
+		/// <summary>
 		/// Gets or sets if modified since.
 		/// </summary>
 		/// <value>If modified since.</value>
@@ -218,6 +224,9 @@ namespace Faithlife.WebRequests
 				request.Headers.Authorization = AuthenticationHeaderValue.Parse(authorizationHeader);
 
 			handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+
+			if (IfMatch != null)
+				request.Headers.IfMatch.ParseAdd(IfMatch);
 
 			if (IfModifiedSince.HasValue)
 				request.Headers.IfModifiedSince = IfModifiedSince.Value;

--- a/src/Faithlife.WebRequests/WebServiceRequestUtility.cs
+++ b/src/Faithlife.WebRequests/WebServiceRequestUtility.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Faithlife.Utility;
 
@@ -184,6 +183,19 @@ namespace Faithlife.WebRequests
 		public static TWebServiceRequest WithContent<TWebServiceRequest>(this TWebServiceRequest request, HttpContent content) where TWebServiceRequest : WebServiceRequestBase
 		{
 			request.Content = content;
+			return request;
+		}
+
+		/// <summary>
+		/// Sets the IfMatch of the WebServiceRequest.
+		/// </summary>
+		/// <typeparam name="TWebServiceRequest">The type of the web service request.</typeparam>
+		/// <param name="request">The request.</param>
+		/// <param name="eTag">The ETag.</param>
+		/// <returns>The request.</returns>
+		public static TWebServiceRequest WithIfMatch<TWebServiceRequest>(this TWebServiceRequest request, string eTag) where TWebServiceRequest : WebServiceRequestBase
+		{
+			request.IfMatch = eTag;
 			return request;
 		}
 


### PR DESCRIPTION
This addition allows for optimistic concurrency support via the If-Match header.  I copy/pasted the If-None-Match header code (which also deals in e-tags).  Local testing with `request.WithIfNoneMatch("\"testetag\"").WithIfMatch("\"testetag\"")` now results in:
```
...
If-Match: "testetag"
If-None-Match: "testetag"
Content-Type: application/json
...
```