### PR TITLE
Allow unmapped AutoWebServiceResponse HTTP status codes and expose HTTP headers.

### DIFF
--- a/src/Faithlife.WebRequests/Json/AutoWebServiceRequest.cs
+++ b/src/Faithlife.WebRequests/Json/AutoWebServiceRequest.cs
@@ -76,10 +76,6 @@ namespace Faithlife.WebRequests.Json
 				isStatusCodeHandled = true;
 			}
 
-			// make sure status code is handled
-			if (!isStatusCodeHandled)
-				throw await CreateExceptionAsync(info, "Status code not handled.").ConfigureAwait(false);
-
 			// read headers
 			foreach (var header in webResponse.Headers)
 			{
@@ -114,7 +110,7 @@ namespace Faithlife.WebRequests.Json
 			// allow response to read extra data
 			AutoWebServiceResponse autoWebServiceResponse = response as AutoWebServiceResponse;
 			if (autoWebServiceResponse != null)
-				await autoWebServiceResponse.OnResponseHandledAsync(info).ConfigureAwait(false);
+				await autoWebServiceResponse.OnResponseHandledAsync(info, isStatusCodeHandled).ConfigureAwait(false);
 
 			// detach response if necessary
 			if (content is WebResponseStream)

--- a/src/Faithlife.WebRequests/Json/AutoWebServiceResponse.cs
+++ b/src/Faithlife.WebRequests/Json/AutoWebServiceResponse.cs
@@ -11,6 +11,16 @@ namespace Faithlife.WebRequests.Json
 	public abstract class AutoWebServiceResponse
 	{
 		/// <summary>
+		/// Gets the HTTP headers on the response.
+		/// </summary>
+		public HttpResponseHeaders Headers { get; private set; }
+
+		/// <summary>
+		/// Gets the HTTP status code on the response.
+		/// </summary>
+		public HttpStatusCode StatusCode => m_responseStatusCode ?? throw new InvalidOperationException("Response data has not yet been populated.");
+
+		/// <summary>
 		/// Creates an exception for the response.
 		/// </summary>
 		/// <returns>A new exception for the response.</returns>
@@ -21,7 +31,7 @@ namespace Faithlife.WebRequests.Json
 				requestMethod: m_requestMethod,
 				requestUri: m_requestUri,
 				responseStatusCode: m_responseStatusCode,
-				responseHeaders: m_responseHeaders,
+				responseHeaders: Headers,
 				responseContentType: m_responseContentType,
 				responseContentLength: m_responseContentLength,
 				responseContentPreview: m_responseContentPreview,
@@ -44,7 +54,7 @@ namespace Faithlife.WebRequests.Json
 			m_requestMethod = info.WebResponse.RequestMessage.Method.Method;
 			m_requestUri = info.WebResponse.RequestMessage.RequestUri;
 			m_responseStatusCode = info.WebResponse.StatusCode;
-			m_responseHeaders = info.WebResponse.Headers;
+			Headers = info.WebResponse.Headers;
 			m_responseContentType = info.WebResponse.Content?.Headers?.ContentType?.ToString();
 			m_responseContentLength = info.WebResponse.Content?.Headers?.ContentLength;
 
@@ -63,7 +73,6 @@ namespace Faithlife.WebRequests.Json
 		string m_requestMethod;
 		Uri m_requestUri;
 		HttpStatusCode? m_responseStatusCode;
-		HttpHeaders m_responseHeaders;
 		string m_responseContentType;
 		long? m_responseContentLength;
 		string m_responseContentPreview;

--- a/src/Faithlife.WebRequests/Json/AutoWebServiceResponse.cs
+++ b/src/Faithlife.WebRequests/Json/AutoWebServiceResponse.cs
@@ -16,6 +16,11 @@ namespace Faithlife.WebRequests.Json
 		public HttpResponseHeaders Headers { get; private set; }
 
 		/// <summary>
+		/// Gets whether or not the response's content was able to be mapped to a strongly typed property corresponding to the HTTP status code.
+		/// </summary>
+		public bool IsStatusCodeHandled { get; private set; }
+
+		/// <summary>
 		/// Gets the HTTP status code on the response.
 		/// </summary>
 		public HttpStatusCode StatusCode => m_responseStatusCode ?? throw new InvalidOperationException("Response data has not yet been populated.");
@@ -36,6 +41,15 @@ namespace Faithlife.WebRequests.Json
 				responseContentLength: m_responseContentLength,
 				responseContentPreview: m_responseContentPreview,
 				innerException: innerException);
+		}
+
+		/// <summary>
+		/// Throws an exception if the response's content was unable to be mapped to a strongly typed property corresponding to the HTTP status code.
+		/// </summary>
+		public void ThrowIfStatusCodeNotHandled(string message = null)
+		{
+			if (!IsStatusCodeHandled)
+				throw CreateException(message ?? "Status code not handled.");
 		}
 
 		/// <summary>
@@ -65,8 +79,9 @@ namespace Faithlife.WebRequests.Json
 			}
 		}
 
-		internal Task OnResponseHandledAsync(WebServiceResponseHandlerInfo info)
+		internal Task OnResponseHandledAsync(WebServiceResponseHandlerInfo info, bool isStatusCodeHandled)
 		{
+			IsStatusCodeHandled = isStatusCodeHandled;
 			return OnResponseHandledCoreAsync(info);
 		}
 


### PR DESCRIPTION
This change allows clients to handle unmapped HTTP status codes and to check for HTTP headers that aren't specifically declared as properties.  This allows for creation of extension methods for `AutoWebServiceResponse` that do things such as guarantee that authentication was successful (e.g. `StatusCode != HttpStatusCode.Unauthorized`) or check for the existence of certain headers (e.g. `SetCookie`).

**Breaking change**: If there is no matching property for the `response.StatusCode` then _an exception will no longer be thrown_.  This exception is now opt-in via a manual call to `response.ThrowIfStatusCodeNotHandled()`.