### PR TITLE
Return status codes explicitly if the response type expects it.

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -6,7 +6,7 @@ Add changes here when they're committed to the `master` branch. Move them to "Re
 is updated in preparation for publishing an updated NuGet package.
 
 Prefix the description of the change with `[major]`, `[minor]` or `[patch]` in accordance with [SemVer](http://semver.org).
-
+* [minor] Support responses with an explicit `StatusCode` property.
 * [minor] Add `WebServiceRequestSettings.StartTrace` callback.
 
 ## Released

--- a/src/Faithlife.WebRequests/Json/AutoWebServiceRequest.cs
+++ b/src/Faithlife.WebRequests/Json/AutoWebServiceRequest.cs
@@ -78,7 +78,7 @@ namespace Faithlife.WebRequests.Json
 				isStatusCodeHandled = true;
 			}
 
-			PropertyInfo statusCodeProperty = GetProperty(responseType, nameof(HttpResponseMessage.StatusCode));
+			PropertyInfo statusCodeProperty = GetProperty(responseType, "StatusCode");
 			if (statusCodeProperty != null && statusCodeProperty.CanWrite)
 			{
 				Type statusCodePropertyType = statusCodeProperty.PropertyType;
@@ -143,7 +143,12 @@ namespace Faithlife.WebRequests.Json
 
 		private static PropertyInfo GetProperty(Type type, string propertyName)
 		{
-			return type.GetRuntimeProperties().FirstOrDefault(x => x.GetMethod != null && !x.GetMethod.IsStatic && string.Equals(x.Name, propertyName, StringComparison.OrdinalIgnoreCase));
+			var property = type.GetRuntimeProperties().FirstOrDefault(x => x.GetMethod != null && !x.GetMethod.IsStatic && string.Equals(x.Name, propertyName, StringComparison.OrdinalIgnoreCase));
+
+			if (property != null && property.SetMethod == null)
+				property = property.DeclaringType.GetRuntimeProperty(property.Name);
+
+			return property;
 		}
 
 		private async Task<object> ReadContentAsAsync(WebServiceResponseHandlerInfo<TResponse> info, Type propertyType)

--- a/src/Faithlife.WebRequests/Json/ExplicitStatusResponse.cs
+++ b/src/Faithlife.WebRequests/Json/ExplicitStatusResponse.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Faithlife.WebRequests.Json
+{
+	/// <summary>
+	/// AutoWebServiceRequest responses with an explicitly set status code. 
+	/// </summary>
+	public abstract class ExplicitStatusResponse : AutoWebServiceResponse
+	{
+		/// <summary>
+		/// Exposes the response status code.
+		/// </summary>
+		public HttpStatusCode StatusCode { get; internal set; } // internal instead of private to avoid being compiled away
+
+		/// <summary>
+		/// Exposes the response headers.
+		/// </summary>
+		public HttpResponseHeaders Headers { get; private set; }
+
+		/// <summary>
+		/// Sets Headers property.
+		/// </summary>
+		/// <param name="info">The web service response handler information.</param>
+		protected override async Task OnResponseHandledCoreAsync(WebServiceResponseHandlerInfo info)
+		{
+			await base.OnResponseHandledCoreAsync(info).ConfigureAwait(false);
+			Headers = info.WebResponse.Headers;
+		}
+	}
+}

--- a/src/Faithlife.WebRequests/Json/GenericStatusCodeResponse.cs
+++ b/src/Faithlife.WebRequests/Json/GenericStatusCodeResponse.cs
@@ -7,12 +7,12 @@ namespace Faithlife.WebRequests.Json
 	/// <summary>
 	/// AutoWebServiceRequest responses with an explicitly set status code. 
 	/// </summary>
-	public abstract class ExplicitStatusResponse : AutoWebServiceResponse
+	public class GenericStatusCodeResponse : AutoWebServiceResponse
 	{
 		/// <summary>
 		/// Exposes the response status code.
 		/// </summary>
-		public HttpStatusCode StatusCode { get; internal set; } // internal instead of private to avoid being compiled away
+		public HttpStatusCode StatusCode { get; private set; }
 
 		/// <summary>
 		/// Exposes the response headers.

--- a/tests/Faithlife.WebRequests.Tests/EchoTests.cs
+++ b/tests/Faithlife.WebRequests.Tests/EchoTests.cs
@@ -134,9 +134,9 @@ namespace Faithlife.WebRequests.Tests
 		[TestCase(HttpStatusCode.BadGateway)]
 		[TestCase(HttpStatusCode.ServiceUnavailable)]
 		[TestCase(HttpStatusCode.GatewayTimeout)]
-		public async Task EchoExplicitStatusResponse(HttpStatusCode statusCode)
+		public async Task EchoGenericStatusCodeResponse(HttpStatusCode statusCode)
 		{
-			var request = new AutoWebServiceRequest<EchoResponseExplicitStatusResponse>(new Uri(m_uriPrefix + "echo"))
+			var request = new AutoWebServiceRequest<GenericStatusCodeResponse>(new Uri(m_uriPrefix + "echo"))
 				.WithJsonContent(new EchoRequestDto { StatusCode = (int) statusCode });
 
 			var response = await request.GetResponseAsync();
@@ -154,9 +154,9 @@ namespace Faithlife.WebRequests.Tests
 		[TestCase(HttpStatusCode.BadGateway)]
 		[TestCase(HttpStatusCode.ServiceUnavailable)]
 		[TestCase(HttpStatusCode.GatewayTimeout)]
-		public async Task EchoExplicitStatusAsIntResponse(HttpStatusCode statusCode)
+		public async Task EchoGenericStatusCodeAsIntResponse(HttpStatusCode statusCode)
 		{
-			var request = new AutoWebServiceRequest<EchoResponseExplicitStatusAsIntResponse>(new Uri(m_uriPrefix + "echo"))
+			var request = new AutoWebServiceRequest<EchoResponseGenericStatusCodeAsIntResponse>(new Uri(m_uriPrefix + "echo"))
 				.WithJsonContent(new EchoRequestDto { StatusCode = (int) statusCode });
 
 			var response = await request.GetResponseAsync();
@@ -185,10 +185,7 @@ namespace Faithlife.WebRequests.Tests
 			public bool NoContent { get; set; }
 		}
 
-		class EchoResponseExplicitStatusResponse : ExplicitStatusResponse
-		{}
-
-		class EchoResponseExplicitStatusAsIntResponse : AutoWebServiceResponse
+		class EchoResponseGenericStatusCodeAsIntResponse : AutoWebServiceResponse
 		{
 			public int StatusCode { get; internal set; }
 		}

--- a/tests/Faithlife.WebRequests.Tests/EchoTests.cs
+++ b/tests/Faithlife.WebRequests.Tests/EchoTests.cs
@@ -124,6 +124,45 @@ namespace Faithlife.WebRequests.Tests
 			Assert.AreEqual(HttpStatusCode.InternalServerError, exception.ResponseStatusCode);
 		}
 
+		[TestCase(HttpStatusCode.OK)]
+		[TestCase(HttpStatusCode.Created)]
+		[TestCase(HttpStatusCode.BadRequest)]
+		[TestCase(HttpStatusCode.Unauthorized)]
+		[TestCase(HttpStatusCode.Forbidden)]
+		[TestCase(HttpStatusCode.NotFound)]
+		[TestCase(HttpStatusCode.InternalServerError)]
+		[TestCase(HttpStatusCode.BadGateway)]
+		[TestCase(HttpStatusCode.ServiceUnavailable)]
+		[TestCase(HttpStatusCode.GatewayTimeout)]
+		public async Task EchoExplicitStatusResponse(HttpStatusCode statusCode)
+		{
+			var request = new AutoWebServiceRequest<EchoResponseExplicitStatusResponse>(new Uri(m_uriPrefix + "echo"))
+				.WithJsonContent(new EchoRequestDto { StatusCode = (int) statusCode });
+
+			var response = await request.GetResponseAsync();
+			Assert.AreEqual(statusCode, response.StatusCode);
+			CollectionAssert.IsNotEmpty(response.Headers);
+		}
+
+		[TestCase(HttpStatusCode.OK)]
+		[TestCase(HttpStatusCode.Created)]
+		[TestCase(HttpStatusCode.BadRequest)]
+		[TestCase(HttpStatusCode.Unauthorized)]
+		[TestCase(HttpStatusCode.Forbidden)]
+		[TestCase(HttpStatusCode.NotFound)]
+		[TestCase(HttpStatusCode.InternalServerError)]
+		[TestCase(HttpStatusCode.BadGateway)]
+		[TestCase(HttpStatusCode.ServiceUnavailable)]
+		[TestCase(HttpStatusCode.GatewayTimeout)]
+		public async Task EchoExplicitStatusAsIntResponse(HttpStatusCode statusCode)
+		{
+			var request = new AutoWebServiceRequest<EchoResponseExplicitStatusAsIntResponse>(new Uri(m_uriPrefix + "echo"))
+				.WithJsonContent(new EchoRequestDto { StatusCode = (int) statusCode });
+
+			var response = await request.GetResponseAsync();
+			Assert.AreEqual((int) statusCode, response.StatusCode);
+		}
+
 		class EchoRequestDto
 		{
 			public string Message { get; set; }
@@ -144,6 +183,14 @@ namespace Faithlife.WebRequests.Tests
 		{
 			public EchoResponseDto OK { get; set; }
 			public bool NoContent { get; set; }
+		}
+
+		class EchoResponseExplicitStatusResponse : ExplicitStatusResponse
+		{}
+
+		class EchoResponseExplicitStatusAsIntResponse : AutoWebServiceResponse
+		{
+			public int StatusCode { get; internal set; }
 		}
 
 		HttpListener m_listener;


### PR DESCRIPTION
Handle any status code without mandating a property be specifically named for the status code on a response object. This change will give us greater flexibility when guaranteeing successful authentication or the existence of certain headers on the response. 

cc @ejball --I don't appear to have permissions to assign this to you.