### PR TITLE
Ignore exceptions in ReadContentPreviewAsync

### DIFF
--- a/src/Faithlife.WebRequests/HttpResponseMessageUtility.cs
+++ b/src/Faithlife.WebRequests/HttpResponseMessageUtility.cs
@@ -54,15 +54,23 @@ namespace Faithlife.WebRequests
 		/// <returns>The content preview.</returns>
 		public static async Task<string> ReadContentPreviewAsync(HttpResponseMessage response)
 		{
-			Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-			using (WrappingStream wrappingStream = new WrappingStream(stream, Ownership.None))
-			using (StreamReader reader = new StreamReader(stream))
+			try
 			{
-				char[] buffer = new char[c_contentPreviewCharacterCount];
-				int readCount = await reader.ReadBlockAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
-				if (readCount == buffer.Length)
-					buffer[readCount - 1] = '\u2026';
-				return new string(buffer, 0, readCount);
+				Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+				using (WrappingStream wrappingStream = new WrappingStream(stream, Ownership.None))
+				using (StreamReader reader = new StreamReader(stream))
+				{
+					char[] buffer = new char[c_contentPreviewCharacterCount];
+					int readCount = await reader.ReadBlockAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+					if (readCount == buffer.Length)
+						buffer[readCount - 1] = '\u2026';
+					return new string(buffer, 0, readCount);
+				}
+			}
+			catch (Exception)
+			{
+				// ignore failure to read a content preview
+				return null;
 			}
 		}
 


### PR DESCRIPTION
When `CreateWebServiceExceptionWithContentPreviewAsync` is being called for an error response that can't be read, don't throw a new exception that will mask the original one.

The code this was ported from used `HttpWebRequestUtility.DoReadResponseStream`, which ignores HTTP-related exceptions and returns `default(T)`; this change seems like a reasonable equivalent.

Sample call stack exhibiting the problem this PR fixes:

```
Message: ArgumentException: Stream was not readable. in System.IO.StreamReader..ctor(Stream stream, Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize, Boolean leaveOpen)
System.IO.StreamReader..ctor(Stream stream, Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize, Boolean leaveOpen):82
System.IO.StreamReader..ctor(Stream stream):8
Faithlife.WebRequests.HttpResponseMessageUtility+<ReadContentPreviewAsync>d__2.MoveNext():159
System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw():12
System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task):40
Faithlife.WebRequests.HttpResponseMessageUtility+<CreateWebServiceExceptionWithContentPreviewAsync>d__1.MoveNext():109
System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw():12
System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task):40
System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter.GetResult():11
Faithlife.WebRequests.Json.AutoWebServiceRequest`1+<HandleResponseCoreAsync>d__6.MoveNext():730
System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw():12
System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task):40
Faithlife.WebRequests.WebServiceRequestBase`1+<HandleResponseAsync>d__9.MoveNext():147
System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw():12
System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task):40
Faithlife.WebRequests.WebServiceRequestBase`1+<GetResponseAsync>d__1.MoveNext()
```