### PR TITLE
Support additional json content types.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.9.1</VersionPrefix>
+    <VersionPrefix>0.10.0</VersionPrefix>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.9.1</VersionPrefix>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,6 +1,6 @@
 # Version History
 
-### 0.9.1
+### 0.10.0
 
 * Support additional json content types (e.g., application/vnd.api+json).
 * Breaking change! Content-type must not have extra text after "json" (aside from parameters after a semicolon).

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,5 +1,9 @@
 # Version History
 
+### 0.9.1
+
+* Support additional json content types (e.g., application/vnd.api+json).
+
 ### 0.9.0
 
 * Add `netstandard2.1` target framework.

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -3,6 +3,7 @@
 ### 0.9.1
 
 * Support additional json content types (e.g., application/vnd.api+json).
+* Breaking change! Content-type must not have extra text after "json" (aside from parameters after a semicolon).
 
 ### 0.9.0
 

--- a/src/Faithlife.WebRequests/Faithlife.WebRequests.csproj
+++ b/src/Faithlife.WebRequests/Faithlife.WebRequests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-  <ItemGroup>                   
+  <ItemGroup>
     <InternalsVisibleTo Include="Faithlife.WebRequests.Tests" />
     <PackageReference Include="Faithlife.Json" Version="0.7.0" />
     <PackageReference Include="Faithlife.Utility" Version="0.9.0" />

--- a/src/Faithlife.WebRequests/Faithlife.WebRequests.csproj
+++ b/src/Faithlife.WebRequests/Faithlife.WebRequests.csproj
@@ -6,7 +6,8 @@
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup>                   
+    <InternalsVisibleTo Include="Faithlife.WebRequests.Tests" />
     <PackageReference Include="Faithlife.Json" Version="0.7.0" />
     <PackageReference Include="Faithlife.Utility" Version="0.9.0" />
     <PackageReference Include="JetBrains.Annotations" Version="10.4.0" />

--- a/src/Faithlife.WebRequests/Json/JsonResponseUtility.cs
+++ b/src/Faithlife.WebRequests/Json/JsonResponseUtility.cs
@@ -10,13 +10,7 @@ namespace Faithlife.WebRequests.Json
 		/// </summary>
 		/// <param name="contentType">The Content-Type http header value.</param>
 		/// <returns>True if the content type is "application/json" or "application/schema+json".</returns>
-		public static bool IsJsonContentType(string contentType)
-		{
-			if (contentType == null)
-				throw new ArgumentNullException(nameof(contentType));
-
-			return s_jsonContentTypeRegex.IsMatch(contentType);
-		}
+		public static bool IsJsonContentType(string contentType) => s_jsonContentTypeRegex.IsMatch(contentType ?? throw new ArgumentNullException(nameof(contentType)));
 
 		private static readonly Regex s_jsonContentTypeRegex = new Regex(@"^\s*application\/([^\s;]+\+)?json\s*($|;)");
 	}

--- a/src/Faithlife.WebRequests/Json/JsonResponseUtility.cs
+++ b/src/Faithlife.WebRequests/Json/JsonResponseUtility.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Faithlife.WebRequests.Json
+{
+	internal static class JsonResponseUtility
+	{
+		/// <summary>
+		/// Returns true if the content type is a JSON content type.
+		/// </summary>
+		/// <param name="contentType">The response.</param>
+		/// <returns>True if the content type is "application/json" or "application/schema+json".</returns>
+		public static bool IsJsonContentType(string contentType)
+		{
+			if (contentType == null)
+				throw new ArgumentNullException(nameof(contentType));
+
+			// Length comparison is to short-circuit more-expensive regex check. Could potentially call Trim() and check StartsWith "application" as another performance optimization.
+			return contentType.Length >= 16 && s_jsonContentTypeRegex.IsMatch(contentType);
+		}
+
+		private static readonly Regex s_jsonContentTypeRegex = new Regex(@"^\s*application\/([^\s;]+\+)?json");
+	}
+}

--- a/src/Faithlife.WebRequests/Json/JsonResponseUtility.cs
+++ b/src/Faithlife.WebRequests/Json/JsonResponseUtility.cs
@@ -18,6 +18,6 @@ namespace Faithlife.WebRequests.Json
 			return s_jsonContentTypeRegex.IsMatch(contentType);
 		}
 
-		private static readonly Regex s_jsonContentTypeRegex = new Regex(@"^\s*application\/([^\s;]+\+)?json");
+		private static readonly Regex s_jsonContentTypeRegex = new Regex(@"^\s*application\/([^\s;]+\+)?json\s*($|;)");
 	}
 }

--- a/src/Faithlife.WebRequests/Json/JsonResponseUtility.cs
+++ b/src/Faithlife.WebRequests/Json/JsonResponseUtility.cs
@@ -8,15 +8,14 @@ namespace Faithlife.WebRequests.Json
 		/// <summary>
 		/// Returns true if the content type is a JSON content type.
 		/// </summary>
-		/// <param name="contentType">The response.</param>
+		/// <param name="contentType">The Content-Type http header value.</param>
 		/// <returns>True if the content type is "application/json" or "application/schema+json".</returns>
 		public static bool IsJsonContentType(string contentType)
 		{
 			if (contentType == null)
 				throw new ArgumentNullException(nameof(contentType));
 
-			// Length comparison is to short-circuit more-expensive regex check. Could potentially call Trim() and check StartsWith "application" as another performance optimization.
-			return contentType.Length >= 16 && s_jsonContentTypeRegex.IsMatch(contentType);
+			return s_jsonContentTypeRegex.IsMatch(contentType);
 		}
 
 		private static readonly Regex s_jsonContentTypeRegex = new Regex(@"^\s*application\/([^\s;]+\+)?json");

--- a/src/Faithlife.WebRequests/Json/JsonWebResponseUtility.cs
+++ b/src/Faithlife.WebRequests/Json/JsonWebResponseUtility.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -19,14 +18,13 @@ namespace Faithlife.WebRequests.Json
 		/// Returns true if the response content uses the JSON content type.
 		/// </summary>
 		/// <param name="response">The response.</param>
-		/// <returns>True if the response content uses the JSON content type ("application/json") and the content is not empty.</returns>
+		/// <returns>True if the response content uses the JSON content type ("application/json" or "application/schema+json") and the content is not empty.</returns>
 		public static bool HasJson(this HttpResponseMessage response)
 		{
 			// Allow null ContentLength
 			var hasJson = response.Content?.Headers.ContentLength != 0;
 			var contentType = response.Content?.Headers.ContentType?.ToString();
-			hasJson &= contentType is object && contentType.Length >= JsonWebServiceContent.JsonContentType.Length &&
-				contentType.Trim().StartsWith(JsonWebServiceContent.JsonContentType, StringComparison.Ordinal);
+			hasJson &= contentType is object && JsonResponseUtility.IsJsonContentType(contentType);
 
 			return hasJson;
 		}

--- a/src/Faithlife.WebRequests/Json/JsonWebServiceResponseUtility.cs
+++ b/src/Faithlife.WebRequests/Json/JsonWebServiceResponseUtility.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
 using Faithlife.Utility;
@@ -18,13 +16,12 @@ namespace Faithlife.WebRequests.Json
 		/// Returns true if the response content uses the JSON content type.
 		/// </summary>
 		/// <param name="response">The response.</param>
-		/// <returns>True if the response content uses the JSON content type ("application/json") and the content is not empty.</returns>
+		/// <returns>True if the response content uses the JSON content type ("application/json" or "application/schema+json") and the content is not empty.</returns>
 		public static bool HasJson(this WebServiceResponse response)
 		{
 			bool hasJson = response.Content?.Headers.ContentLength > 0;
 			var contentType = response.Content?.Headers.ContentType?.ToString();
-			hasJson &= contentType is object && contentType.Length >= JsonWebServiceContent.JsonContentType.Length &&
-				contentType.Trim().StartsWith(JsonWebServiceContent.JsonContentType, StringComparison.Ordinal);
+			hasJson &= contentType is object && JsonResponseUtility.IsJsonContentType(contentType);
 
 			return hasJson;
 		}

--- a/tests/Faithlife.WebRequests.Tests/JsonResponseUtilityTests.cs
+++ b/tests/Faithlife.WebRequests.Tests/JsonResponseUtilityTests.cs
@@ -17,9 +17,6 @@ namespace Faithlife.WebRequests.Tests
 		[TestCase(false, "text/html; charset=application/json")]
 		[TestCase(false, "application/html; charset=application/json")]
 		[TestCase(false, "application/html; charset=application/vnd.api+json")]
-		public void TestIsJsonContentType(bool isJson, string contentType)
-		{
-			Assert.AreEqual(isJson, JsonResponseUtility.IsJsonContentType(contentType));
-		}
+		public void TestIsJsonContentType(bool isJson, string contentType) => Assert.AreEqual(isJson, JsonResponseUtility.IsJsonContentType(contentType));
 	}
 }

--- a/tests/Faithlife.WebRequests.Tests/JsonResponseUtilityTests.cs
+++ b/tests/Faithlife.WebRequests.Tests/JsonResponseUtilityTests.cs
@@ -1,0 +1,23 @@
+using Faithlife.WebRequests.Json;
+using NUnit.Framework;
+
+namespace Faithlife.WebRequests.Tests
+{
+	[TestFixture]
+	public sealed class JsonResponseUtilityTests
+	{
+		[TestCase("application/json", true)]
+		[TestCase(" application/json", true)]
+		[TestCase(" application/vnd.api+json", true)]
+		[TestCase("application/vnd.api+json", true)]
+		[TestCase("text/html", false)]
+		[TestCase("text/html; charset=UTF-8", false)]
+		[TestCase("text/html; charset=application/json", false)]
+		[TestCase("application/html; charset=application/json", false)]
+		[TestCase("application/html; charset=application/vnd.api+json", false)]
+		public void TestIsJsonContentType(string contentType, bool isJson)
+		{
+			Assert.AreEqual(isJson, JsonResponseUtility.IsJsonContentType(contentType));
+		}
+	}
+}

--- a/tests/Faithlife.WebRequests.Tests/JsonResponseUtilityTests.cs
+++ b/tests/Faithlife.WebRequests.Tests/JsonResponseUtilityTests.cs
@@ -6,16 +6,18 @@ namespace Faithlife.WebRequests.Tests
 	[TestFixture]
 	public sealed class JsonResponseUtilityTests
 	{
-		[TestCase("application/json", true)]
-		[TestCase(" application/json", true)]
-		[TestCase(" application/vnd.api+json", true)]
-		[TestCase("application/vnd.api+json", true)]
-		[TestCase("text/html", false)]
-		[TestCase("text/html; charset=UTF-8", false)]
-		[TestCase("text/html; charset=application/json", false)]
-		[TestCase("application/html; charset=application/json", false)]
-		[TestCase("application/html; charset=application/vnd.api+json", false)]
-		public void TestIsJsonContentType(string contentType, bool isJson)
+		[TestCase(true, "application/json")]
+		[TestCase(true, " application/json")]
+		[TestCase(true, " application/vnd.api+json")]
+		[TestCase(true, "application/vnd.api+json")]
+		[TestCase(true, "application/vnd.oracle.resource+json; type=singular; charset=UTF-8")]
+		[TestCase(false, "application/geo+json-seq")]
+		[TestCase(false, "text/html")]
+		[TestCase(false, "text/html; charset=UTF-8")]
+		[TestCase(false, "text/html; charset=application/json")]
+		[TestCase(false, "application/html; charset=application/json")]
+		[TestCase(false, "application/html; charset=application/vnd.api+json")]
+		public void TestIsJsonContentType(bool isJson, string contentType)
 		{
 			Assert.AreEqual(isJson, JsonResponseUtility.IsJsonContentType(contentType));
 		}


### PR DESCRIPTION
It's not clear to me from https://github.com/Faithlife/FaithlifeWebRequests/blob/master/CONTRIBUTING.md whether I should update the version in Directory.Build.props and update VersionHistory.md or if that is done as a separate step.

The problem this solves for me personally is using FaithlifeWebRequests with NetSuite's REST API, which returns content type `application/vnd.oracle.resource+json; type=singular; charset=UTF-8` even when I specify an accept header of "application/json".

@bgrainger requested your review since you're the last one to update the version. EDIT: Assigned to Ed because he reviewed it :) Thanks @ejball 